### PR TITLE
replaceViewControllers prompts the completion

### DIFF
--- a/Sources/Extensions/UIViewController+Hero.swift
+++ b/Sources/Extensions/UIViewController+Hero.swift
@@ -168,6 +168,16 @@ extension UINavigationController {
     get { return hero.navigationAnimationTypeString }
     set { hero.navigationAnimationTypeString = newValue }
   }
+  
+  /// This function call the standard setViewControllers() but it also add a completion callback.
+   func setViewControllers(viewControllers: [UIViewController], animated: Bool, completion: (() -> Void)?) {
+		setViewControllers(viewControllers, animated: animated)
+		guard animated, let coordinator = transitionCoordinator else {
+			DispatchQueue.main.async { completion?() }
+			return
+		}
+		coordinator.animate(alongsideTransition: nil) { _ in completion?() }
+	}
 }
 
 public extension HeroExtension where Base: UITabBarController {
@@ -311,7 +321,7 @@ public extension HeroExtension where Base: UIViewController {
       if navigationController.hero.isEnabled {
         hero.forceNotInteractive = true
       }
-      navigationController.setViewControllers(vcs, animated: true)
+      navigationController.setViewControllers(viewControllers: vcs, animated: true, completion: completion)
     } else if let container = base.view.superview {
       let parentVC = base.presentingViewController
       hero.transition(from: base, to: next, in: container) { [weak base] finished in


### PR DESCRIPTION
extended the UINavigationController with a new setViewControllers methods that accept a completion.
Now the replaceViewControllers launch correctly the completion